### PR TITLE
Fixing invalid GATT schema.

### DIFF
--- a/BTIDES_GATT.json
+++ b/BTIDES_GATT.json
@@ -197,11 +197,11 @@
     "CharacteristicValue": {
       "type": "object",
       "description": "Structure for GATT Characteristic (\"attribute type\" UUID always 0x2803). Optional io_array captures input/output seen to/from this Characteristic Value.",
+      "required": [
+        "handle",
+        "value_uuid"
+      ],
       "properties": {
-        "required": [
-          "handle",
-          "value_uuid"
-        ],
         "handle": {
           "description": "2-byte ATT handle number of the \"Characteristic\" attribute itself.",
           "type": "integer",


### PR DESCRIPTION
## Problem Description

The GATT schema fails to validate through a number of JSON schema validators.  The main issue is that the type `CharacteristicValue` has its `required` field nested at the wrong level.  It is under the `properties` field, when it should be adjacent to the `properties` field.

Please accept this pull request to have those changes merged in.  I am not well versed with the BTIDES data format as of today, so if I am missing something or misinterpreting what's intended with the schema, please let me know.

I've tested the original schemas and the changes in this pull request against two validators.

## Rust Validator

The first being the Rust crate `jsonschema`.  The files fail to validate, but do not give an indication as to why.  Below is a quick "[rust-script](https://crates.io/crates/rust-script)" to run through all the files.

```rust
#!/usr/bin/env rust-script
//! ```cargo
//! [dependencies]
//! jsonschema = "0.30.0"
//! serde_json = "1.0.140"
//! ```

use std::path::PathBuf;

use jsonschema;
use serde_json;

fn get_json_paths(dir: &PathBuf) -> Vec<PathBuf> {
    let mut paths = std::fs::read_dir(dir)
        .unwrap()
        .filter_map(|res| res.ok())
        .map(|dir_entry| dir_entry.path())
        .filter_map(|path| {
            if path.extension().map_or(false, |ext| ext == "json") {
                Some(path.canonicalize().unwrap())
            } else {
                None
            }
        })
        .collect::<Vec<_>>();
    paths.sort();
    paths
}

fn main() {
    let btides_dir = std::env::current_dir().unwrap().join("BTIDES_Schema");
    let all_json_paths = get_json_paths(&btides_dir);

    for json_path in all_json_paths {
        let json_path = json_path.to_str().unwrap();
        println!("Compiling JSON file: {}", &json_path);

        let contents = std::fs::read_to_string(json_path).unwrap();
        let schema = serde_json::from_str::<serde_json::Value>(contents.as_str()).unwrap();

        if ! jsonschema::meta::is_valid(&schema) {
            println!("Invalid Schema: {}", &json_path);
        } else if ! jsonschema::meta::validate(&schema).is_ok() {
            println!("Schema is NOT OK: {}", &json_path);
        }
    }
}
```

## Online Validator

Once I determined which file(s) were invalid, I picked the first [online JSON schema validator](https://www.liquid-technologies.com/online-json-schema-validator) that popped up from a quick Google search.  Since that validator does not have access to the referenced definitions in `BTIDES_base.json`, I did manually copy/paste the definitions from the base into the schema for the online validator.  I copied in these definitions:

* UUID
* UUID16_hex_str
* UUID128_hex_str

Then removed any remaining references to the base file (so all references were internal references).  That online validator pin-pointed the issue.